### PR TITLE
Add app.R for Posit Connect deployment and ignore for Rbuild

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@ CODE_OF_CONDUCT.md
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^app.R$

--- a/R/app.R
+++ b/R/app.R
@@ -1,0 +1,2 @@
+pkgload::load_all(".")
+run_app()


### PR DESCRIPTION
Adds an `app.R` script which is needed for publishing to Posit Connect. 
Also adds `app.R` to `.RBuildignore`

Main branch has been deployed to https://connect.strategyunitwm.nhs.uk/rtt_compartmental_modelling by @morganle-48

